### PR TITLE
Fix of non subscriptable error in bound_rad

### DIFF
--- a/ppmpy/ppm.py
+++ b/ppmpy/ppm.py
@@ -1645,6 +1645,7 @@ class PPMtools:
             at rb are returned if return_var_scale_height == True.
         '''
         cycle_list = any2list(cycles)
+        var_value = any2list(var_value)
         rb = np.zeros(len(cycle_list))
         if return_var_scale_height:
             Hv = np.zeros(len(cycle_list))


### PR DESCRIPTION
The bound_rad method expects that var_value is the same length as the list of dumps. If only one dump is given a dump occurs because var_value is not subscriptable. This is fixed by simply converting var_value into an array.