### PR TITLE
Power spectrum options

### DIFF
--- a/ppmpy/ppm.py
+++ b/ppmpy/ppm.py
@@ -13603,7 +13603,7 @@ class MomsDataSet:
             If > 0 make plot where value is fig number, tuned to show spectrum of ur 
             for a radius in a H-core-25 convective core; may or may not look good for 
             other vars, runs; default is 0
-        momsarray: 3D array or string, optional
+        momsarray: 3D array, optional
             If present, the power spectrum of this array is computed instead
             varloc, dump_start, dump_stop, and dump_step are then ignored
             momsarray must be on the same Cartesian grid as the moms instance.

--- a/ppmpy/ppm.py
+++ b/ppmpy/ppm.py
@@ -13585,6 +13585,8 @@ class MomsDataSet:
         varloc: str, int
             String: for the variable you want if defined on instantiation
             Int: index location of the variable you want the power spectrum of
+            'ur': the signed Ur will be calculated from the ux, uy and uz components
+            '|u|': the rms velocity |U| will be calculated from the ux, uy and uz components
         dump_start: int
             Dump number of the first dump to consider
         dump_stop: int
@@ -13601,10 +13603,10 @@ class MomsDataSet:
             If > 0 make plot where value is fig number, tuned to show spectrum of ur 
             for a radius in a H-core-25 convective core; may or may not look good for 
             other vars, runs; default is 0
-        momsarray: 3D array, optional
+        momsarray: 3D array or string, optional
             If present, the power spectrum of this array is computed instead
             varloc, dump_start, dump_stop, and dump_step are then ignored
-            momsarray must be on the same Cartesian grid as the moms instance
+            momsarray must be on the same Cartesian grid as the moms instance.
 
         Returns
         -------
@@ -13649,9 +13651,7 @@ class MomsDataSet:
 
             for i,dump in enumerate(tqdm(dumps)):
                 try:
-                    # get the desired variable
-                    var = self.get(varloc,fname=dump)
-
+                    # find radius where spectrum is calculated
                     if radiusinput != None:
                         radius = radiusinput
                     elif massinput != None:
@@ -13662,8 +13662,32 @@ class MomsDataSet:
                     # what is lmax at this radius?
                     lmax_r, N, npoints = self.sphericalHarmonics_lmax(radius)
 
-                    # Calculate spherical harmonics up to lmax
-                    var_interp = self.sphericalHarmonics_format(var, radius, lmax=lmax_r)
+                    # get the desired quantity and calculate the spherical harmonics up to lmax
+                    if varloc=='ur':
+                        ux, theta_grid, phi_grid = self.sphericalHarmonics_format('ux', radius, dump, 
+                                                                                  lmax=lmax_r, get_theta_phi_grids=True)
+                        uy = self.sphericalHarmonics_format('uy', radius, dump, lmax=lmax_r)
+                        uz = self.sphericalHarmonics_format('uz', radius, dump, lmax=lmax_r)
+                        theta, phi = np.meshgrid(theta_grid, phi_grid, indexing='ij', sparse=False)
+                        x = radius*np.sin(theta)*np.cos(phi)
+                        y = radius*np.sin(theta)*np.sin(phi)
+                        z = radius*np.cos(theta)
+                        r_len = radius
+                        x /= r_len
+                        y /= r_len
+                        z /= r_len
+                        #x, y, z are now the x,y,z components of the r hat unit vector for each element on the grid
+                        ur = zeros_like(uz)
+                        ur = x*ux + y*uy + z*uz
+                        var_interp = ur
+                    elif varloc=='|u|':
+                        unorm = np.sqrt( self.get('ux',fname=dump)**2 + 
+                                         self.get('uy',fname=dump)**2 +
+                                         self.get('uz',fname=dump)**2 )
+                        var_interp = self.sphericalHarmonics_format(unorm, radius, lmax=lmax_r)
+                    else:
+                        var = self.get(varloc,fname=dump)
+                        var_interp = self.sphericalHarmonics_format(var, radius, lmax=lmax_r)
 
                     # get coefficients and power
                     coeffs = pyshtools.expand.SHExpandDH(var_interp, sampling=2)


### PR DESCRIPTION
I added a new capability to get_power_spectrum method so that |u| and ur can be directly calculated from the ux, uy, uz moms data (similar to what is done for the k-omega diagram method)